### PR TITLE
Fix dependency for imagick installation

### DIFF
--- a/directus-base-layer/Dockerfile
+++ b/directus-base-layer/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y \
     libmcrypt-dev \
     libpng12-dev
 
+RUN apt-get install -y --no-install-recommends libmagickwand-dev && rm -rf /var/lib/apt/lists/*
+
 RUN docker-php-ext-install -j$(nproc) mcrypt pdo_mysql mysqli && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install -j$(nproc) gd


### PR DESCRIPTION
The imagick installation is failing (see #16), with this fix I got the directus-base-layer working on my local environment so the build should be up and running again.