### PR TITLE
Fixes issue with config not being created properly.

### DIFF
--- a/directus-base-layer/usr/local/bin/run-directus
+++ b/directus-base-layer/usr/local/bin/run-directus
@@ -36,7 +36,7 @@ is_database_installed(){
 }
 
 are_configs_generated(){
-  if [ -f /var/www/html/api/config.php -a -f /var/www/html/api/configuration.php ]; then
+  if [ -s /var/www/html/api/config.php -a -s /var/www/html/api/configuration.php ]; then
     return 0
   else
     return 1


### PR DESCRIPTION
I noticed that the fix-directus-permissions goes through and creates config.php and configuration.php, both blank.  As a result, the bootstrap script incorrectly detects the file, and thinks that the config is created. I've swapped the test to check for files that aren't zero sized.

Seems to work now for me.
Addresses #20 