### PR TITLE
Added opcache Support

### DIFF
--- a/directus-base-layer/Dockerfile
+++ b/directus-base-layer/Dockerfile
@@ -15,17 +15,17 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" &&
     mv composer.phar /usr/local/bin/composer
 
 RUN apt-get update && apt-get install -y \
-    libmcrypt-dev \
     libfreetype6-dev \
     libjpeg62-turbo-dev \
-    libmcrypt-dev \
-    libpng12-dev
+    libpng-dev
 
 RUN apt-get install -y --no-install-recommends libmagickwand-dev && rm -rf /var/lib/apt/lists/*
 
-RUN docker-php-ext-install -j$(nproc) mcrypt pdo_mysql mysqli && \
+RUN docker-php-ext-install -j$(nproc) pdo_mysql mysqli && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-    docker-php-ext-install -j$(nproc) gd
+    docker-php-ext-install -j$(nproc) gd && \
+    docker-php-ext-install opcache && \
+    echo 'opcache.validate_timestamps=0' >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 RUN pecl install imagick
 

--- a/directus-base-layer/Dockerfile
+++ b/directus-base-layer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7.1-apache
 MAINTAINER Kristian Frolund "https://github.com/Froelund"
 
 RUN apt-get update && apt-get install -y \

--- a/directus/6.3/Dockerfile
+++ b/directus/6.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM getdirectus/directus-base-layer:0.0.10
+FROM getdirectus/directus-base-layer:0.0.11
 MAINTAINER Luis Santos "luis@luissantos.pt"
 
 RUN get-directus 6.3.9

--- a/directus/6.3/Dockerfile
+++ b/directus/6.3/Dockerfile
@@ -1,4 +1,5 @@
-FROM getdirectus/directus-base-layer:0.0.11
+# Base images after 0.0.10 DON'T have mcrypt
+FROM getdirectus/directus-base-layer:0.0.10
 MAINTAINER Luis Santos "luis@luissantos.pt"
 
 RUN get-directus 6.3.9

--- a/directus/6.4/Dockerfile
+++ b/directus/6.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM getdirectus/directus-base-layer:0.0.10
+FROM getdirectus/directus-base-layer:0.0.11
 MAINTAINER Kristian Frolund "https://github.com/Froelund"
 
 RUN get-directus 6.4.4

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 .PHONY: build-base-image
 build-base-image:
-	docker build  -t 'getdirectus/directus-base-layer:0.0.10' directus-base-layer/
+	docker build  -t 'getdirectus/directus-base-layer:0.0.11' directus-base-layer/
 
 .PHONY: run-base-image
 run-base-image:


### PR DESCRIPTION
Swapped to docker 7.1 (7 was defaulting to 7.2 which is incompatible)
mcrypt no longer supported - couldn't see this in the code so I assume this is okay?  If any vendor libraries, hopefully they have shifted to something else.
Added opcode support and ignore timestamps (afaik php files don't get modified due to a framework in directus?)
Bumped base image to 0.0.11
