### PR TITLE
Feature/opcache disable option

### DIFF
--- a/directus-base-layer/Dockerfile
+++ b/directus-base-layer/Dockerfile
@@ -25,7 +25,8 @@ RUN docker-php-ext-install -j$(nproc) pdo_mysql mysqli && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install -j$(nproc) gd && \
     docker-php-ext-install opcache && \
-    echo 'opcache.validate_timestamps=0' >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+    echo 'opcache.validate_timestamps=0\nopcache.enable=${PHP_OPCACHE_ENABLED}' >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+ENV PHP_OPCACHE_ENABLED=true
 
 RUN pecl install imagick
 

--- a/directus/6.4/Dockerfile
+++ b/directus/6.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM getdirectus/directus-base-layer:0.0.14
+FROM getdirectus/directus-base-layer:0.0.15
 MAINTAINER Kristian Frolund "https://github.com/Froelund"
 
 RUN get-directus 6.4.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
      - MYSQL_ENV_MYSQL_PASSWORD=directus
      - MYSQL_ENV_MYSQL_USER=directus
     # If you use docker for dev or want to test without opcache - disable with env var
-     - PHP_OPCACHE_ENABLED=false
+    #  - PHP_OPCACHE_ENABLED=false
 volumes:
   storage:
     # If you want to define externally, uncomment and adjust as needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
      - MYSQL_PORT_3306_TCP_PORT=3306
      - MYSQL_ENV_MYSQL_PASSWORD=directus
      - MYSQL_ENV_MYSQL_USER=directus
+    # If you use docker for dev or want to test without opcache - disable with env var
+     - PHP_OPCACHE_ENABLED=false
 volumes:
   storage:
     # If you want to define externally, uncomment and adjust as needed

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 .PHONY: build-base-image
 build-base-image:
-	docker build  -t 'getdirectus/directus-base-layer:0.0.11' directus-base-layer/
+	docker build  -t 'getdirectus/directus-base-layer:0.0.15' directus-base-layer/
 
 .PHONY: run-base-image
 run-base-image:


### PR DESCRIPTION
Changed around so opcache.enabled is now controlled through the environment (still defaults to true, figure 'deployed' versions are a more common use case then development).
Addresses #36 
Decided to prepend the php env with PHP_, so make for consistent environment names in the future.